### PR TITLE
[FIX] Portal user login issue

### DIFF
--- a/tko_web_sessions_management/main.py
+++ b/tko_web_sessions_management/main.py
@@ -98,7 +98,7 @@ class TkobrSessionMixin(object):
                     else:
                         # check user groups calendar
                         for group in user.groups_id:
-                            if group.login_calendar_id:
+                            if group.sudo().login_calendar_id:
                                 calendar_set += 1
                                 attendances = attendance_obj.search(request.cr,
                                                                     request.uid, [('calendar_id', '=',


### PR DESCRIPTION
- For user with only portal access, they do not have the access to `res.groups`. Hence we need to have `sudo()` here otherwise the user cannot login and being redirected to 403 page.

The error message in Odoo log:
```
Traceback (most recent call last):
  File "/opt/odoo/odoo-server/addons/website/models/ir_http.py", line 199, in _handle_exception
    response = super(ir_http, self)._handle_exception(exception)
  File "/opt/odoo/odoo-server/openerp/addons/base/ir/ir_http.py", line 145, in _handle_exception
    return request._handle_exception(exception)
  File "/opt/odoo/odoo-server/openerp/http.py", line 675, in _handle_exception
    return super(HttpRequest, self)._handle_exception(exception)
  File "/opt/odoo/odoo-server/openerp/addons/base/ir/ir_http.py", line 171, in _dispatch
    result = request.dispatch()
  File "/opt/odoo/odoo-server/openerp/http.py", line 693, in dispatch
    r = self._call_function(**self.params)
  File "/opt/odoo/odoo-server/openerp/http.py", line 319, in _call_function
    return checked_call(self.db, *args, **kwargs)
  File "/opt/odoo/odoo-server/openerp/service/model.py", line 118, in wrapper
    return f(dbname, *args, **kwargs)
  File "/opt/odoo/odoo-server/openerp/http.py", line 316, in checked_call
    return self.endpoint(*a, **kw)
  File "/opt/odoo/odoo-server/openerp/http.py", line 812, in __call__
    return self.method(*args, **kw)
  File "/opt/odoo/odoo-server/openerp/http.py", line 412, in response_wrap
    response = f(*args, **kw)
  File "/opt/odoo/odoo-server/addons/website/controllers/main.py", line 52, in web_login
    return super(Website, self).web_login(*args, **kw)
  File "/opt/odoo/odoo-server/openerp/http.py", line 412, in response_wrap
    response = f(*args, **kw)
  File "/opt/odoo/odoo-server/addons/auth_signup/controllers/main.py", line 38, in web_login
    response = super(AuthSignupHome, self).web_login(*args, **kw)
  File "/opt/odoo/odoo-server/openerp/http.py", line 412, in response_wrap
    response = f(*args, **kw)
  File "/opt/odoo/custom/tko_web_sessions_management/main.py", line 282, in web_login
    (access_granted, uid, unsuccessful_message) = self.check_session(db, login, password)
  File "/opt/odoo/custom/tko_web_sessions_management/main.py", line 101, in check_session
    if group.login_calendar_id:
  File "/opt/odoo/odoo-server/openerp/fields.py", line 835, in __get__
    self.determine_value(record)
  File "/opt/odoo/odoo-server/openerp/fields.py", line 928, in determine_value
    record._prefetch_field(self)
  File "/opt/odoo/odoo-server/openerp/api.py", line 266, in wrapper
    return new_api(self, *args, **kwargs)
  File "/opt/odoo/odoo-server/openerp/models.py", line 3246, in _prefetch_field
    result = self.read(list(fnames), load='_classic_write')
  File "/opt/odoo/odoo-server/openerp/api.py", line 266, in wrapper
    return new_api(self, *args, **kwargs)
  File "/opt/odoo/odoo-server/openerp/models.py", line 3166, in read
    self.check_access_rights('read')
  File "/opt/odoo/odoo-server/openerp/api.py", line 266, in wrapper
    return new_api(self, *args, **kwargs)
  File "/opt/odoo/odoo-server/openerp/api.py", line 487, in new_api
    result = method(self._model, cr, uid, *args, **kwargs)
  File "/opt/odoo/odoo-server/openerp/models.py", line 3528, in check_access_rights
    return self.pool.get('ir.model.access').check(cr, uid, self._name, operation, raise_exception)
  File "/opt/odoo/odoo-server/openerp/api.py", line 268, in wrapper
    return old_api(self, *args, **kwargs)
  File "<decorator-gen-2>", line 2, in check
  File "/opt/odoo/odoo-server/openerp/tools/cache.py", line 122, in lookup
    value = d[key] = self.method(*args, **kwargs)
  File "/opt/odoo/odoo-server/openerp/addons/base/ir/ir_model.py", line 772, in check
    raise openerp.exceptions.AccessError(msg % msg_params)
AccessError: ('AccessError', u'Sorry, you are not allowed to access this document. Only users with the following access level are currently allowed to do that:\n- Administration/Access Rights\n\t- Human Resources/Employee\n\n(\u6587\u4ef6\u6a21\u578b: res.groups)')
```